### PR TITLE
Change TargetPlatformMinVersion to minimal possible

### DIFF
--- a/src/TreeDumpLibrary/TreeDumpLibrary.csproj
+++ b/src/TreeDumpLibrary/TreeDumpLibrary.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
Hello. Thanks for great library!
In my application I use handwritten code with same functional for cases, when user want to attach visual tree to bug report, so it should works in runtime, not only for e2e-tests.
My application works on 15053+, but I don't see any reason to not target 10240.